### PR TITLE
New Data Fetching Pattern

### DIFF
--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,30 @@
+import { ConditionWidgetSkeleton } from "@/components/ConditionWidget";
+import { HourlyWidgetSkeleton } from "@/components/HourlyWidget";
+import { TempWidgetSkeleton } from "@/components/TempWidget";
+import { UpdatedAtSkeleton } from "@/components/UpdatedAt";
+import { WindWidgetSkeleton } from "@/components/WindWidget";
+import { TwoByTwo, OneByTwo } from "@/components/base-widgets";
+import { FooterButtons } from "./page";
+
+export default function Loading() {
+  return (
+    <>
+      <main className="mx-auto flex h-screen w-fit flex-col items-center gap-8 p-8">
+        <div className="flex flex-col items-center">
+          <h1 className="text-4xl font-semibold">UMD Weather</h1>
+          <UpdatedAtSkeleton />
+        </div>
+        <div className="grid grid-cols-2 grid-rows-3 gap-6 lg:grid-cols-4">
+          <ConditionWidgetSkeleton />
+          <TempWidgetSkeleton />
+          <TwoByTwo className="whitespace-pre">Hello World!</TwoByTwo>
+          <HourlyWidgetSkeleton />
+          <WindWidgetSkeleton />
+          <WindWidgetSkeleton />
+          <OneByTwo>Bonjour</OneByTwo>
+        </div>
+      </main>
+      <FooterButtons />
+    </>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,8 +8,6 @@ import { getOpenWeather } from "@/lib/getOpenWeather";
 import { IconBrandGithub, IconBug, IconInfoCircle } from "@tabler/icons-react";
 import Link from "next/link";
 
-export const revalidate = 0;
-
 export default async function Home() {
   const weather = await getOpenWeather();
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ import { getOpenWeather } from "@/lib/getOpenWeather";
 import { IconBrandGithub, IconBug, IconInfoCircle } from "@tabler/icons-react";
 import Link from "next/link";
 
-export const revalidate = 120;
+export const revalidate = 0;
 
 export default async function Home() {
   const weather = await getOpenWeather();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,8 @@ import { getOpenWeather } from "@/lib/getOpenWeather";
 import { IconBrandGithub, IconBug, IconInfoCircle } from "@tabler/icons-react";
 import Link from "next/link";
 
+export const revalidate = 30;
+
 export default async function Home() {
   const weather = await getOpenWeather();
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,24 +4,27 @@ import { TempWidget } from "@/components/TempWidget";
 import { UpdatedAt } from "@/components/UpdatedAt";
 import { WindWidget } from "@/components/WindWidget";
 import { OneByTwo, TwoByTwo } from "@/components/base-widgets";
+import { getOpenWeather } from "@/lib/getOpenWeather";
 import { IconBrandGithub, IconBug, IconInfoCircle } from "@tabler/icons-react";
 import Link from "next/link";
 
 export default async function Home() {
+  const weather = await getOpenWeather();
+
   return (
     <>
       <main className="mx-auto flex h-screen w-fit flex-col items-center gap-8 p-8">
         <div className="flex flex-col items-center">
           <h1 className="text-4xl font-semibold">UMD Weather</h1>
-          <UpdatedAt />
+          <UpdatedAt weather={weather} />
         </div>
         <div className="grid grid-cols-2 grid-rows-3 gap-6 lg:grid-cols-4">
-          <ConditionWidget />
-          <TempWidget />
+          <ConditionWidget weather={weather} />
+          <TempWidget weather={weather} />
           <TwoByTwo className="whitespace-pre">Hello World!</TwoByTwo>
-          <HourlyWidget />
-          <WindWidget />
-          <WindWidget />
+          <HourlyWidget weather={weather} />
+          <WindWidget weather={weather} />
+          <WindWidget weather={weather} />
           <OneByTwo>Bonjour</OneByTwo>
         </div>
       </main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ import { getOpenWeather } from "@/lib/getOpenWeather";
 import { IconBrandGithub, IconBug, IconInfoCircle } from "@tabler/icons-react";
 import Link from "next/link";
 
-export const revalidate = 30;
+export const revalidate = 120;
 
 export default async function Home() {
   const weather = await getOpenWeather();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,7 +33,7 @@ export default async function Home() {
   );
 }
 
-function FooterButtons() {
+export function FooterButtons() {
   return (
     <>
       <div className="absolute bottom-4 right-4 flex gap-2">

--- a/components/ConditionWidget.tsx
+++ b/components/ConditionWidget.tsx
@@ -4,7 +4,7 @@ import { OneByOne } from "./base-widgets";
 
 export function ConditionWidget({ weather }: { weather: OpenWeather }) {
   return (
-    <OneByOne className="flex flex-col">
+    <OneByOne className="flex flex-col gap-2">
       <div className="flex items-center gap-1 text-sm text-gray-400">
         <IconWeather icon={weather.current.weather[0].icon} size={16} />
         <span>Condition</span>

--- a/components/ConditionWidget.tsx
+++ b/components/ConditionWidget.tsx
@@ -1,12 +1,8 @@
-import { getOpenWeather } from "@/lib/getOpenWeather";
-import { IconCloud, IconSunHigh, IconTemperature } from "@tabler/icons-react";
-import { Suspense } from "react";
-import { OneByOne } from "./base-widgets";
+import { OpenWeather } from "@/lib/getOpenWeather";
 import { IconWeather } from "./IconWeather";
+import { OneByOne } from "./base-widgets";
 
-export async function ConditionWidgetAsync() {
-  const weather = await getOpenWeather();
-
+export function ConditionWidget({ weather }: { weather: OpenWeather }) {
   return (
     <OneByOne className="flex flex-col">
       <div className="flex items-center gap-1 text-sm text-gray-400">
@@ -35,14 +31,5 @@ export function ConditionWidgetSkeleton() {
         <span className="h-6 w-full animate-pulse rounded-lg bg-gray-700 bg-opacity-90"></span>
       </div>
     </OneByOne>
-  );
-}
-
-export function ConditionWidget() {
-  return (
-    <Suspense fallback={<ConditionWidgetSkeleton />}>
-      {/* @ts-expect-error Server Component */}
-      <ConditionWidgetAsync />
-    </Suspense>
   );
 }

--- a/components/HourlyWidget.tsx
+++ b/components/HourlyWidget.tsx
@@ -1,13 +1,10 @@
-import { getOpenWeather } from "@/lib/getOpenWeather";
-import { IconClockHour4 } from "@tabler/icons-react";
-import { Suspense } from "react";
-import { OneByTwo } from "./base-widgets";
-import { IconWeather } from "./IconWeather";
 import { formatTime } from "@/lib/formatTime";
+import { OpenWeather } from "@/lib/getOpenWeather";
+import { IconClockHour4 } from "@tabler/icons-react";
+import { IconWeather } from "./IconWeather";
+import { OneByTwo } from "./base-widgets";
 
-export async function HourlyWidgetAsync() {
-  const weather = await getOpenWeather();
-
+export function HourlyWidget({ weather }: { weather: OpenWeather }) {
   return (
     <OneByTwo className="flex flex-col">
       <div className="flex items-center gap-1 text-sm text-gray-400">
@@ -52,14 +49,5 @@ export function HourlyWidgetSkeleton() {
       </div>
       <span className="mt-1 h-full w-full animate-pulse rounded-lg bg-gray-700 bg-opacity-90"></span>
     </OneByTwo>
-  );
-}
-
-export function HourlyWidget() {
-  return (
-    <Suspense fallback={<HourlyWidgetSkeleton />}>
-      {/* @ts-expect-error Server Component */}
-      <HourlyWidgetAsync />
-    </Suspense>
   );
 }

--- a/components/TempWidget.tsx
+++ b/components/TempWidget.tsx
@@ -1,11 +1,8 @@
-import { getOpenWeather } from "@/lib/getOpenWeather";
+import { OpenWeather } from "@/lib/getOpenWeather";
 import { IconTemperature } from "@tabler/icons-react";
-import { Suspense } from "react";
 import { OneByOne } from "./base-widgets";
 
-export async function TempWidgetAsync() {
-  const weather = await getOpenWeather();
-
+export function TempWidget({ weather }: { weather: OpenWeather }) {
   return (
     <OneByOne className="flex flex-col gap-2">
       <div className="flex items-center gap-1 text-sm text-gray-400">
@@ -34,14 +31,5 @@ export function TempWidgetSkeleton() {
         <span className="mt-1 h-6 w-full animate-pulse rounded-lg bg-gray-700 bg-opacity-90"></span>
       </div>
     </OneByOne>
-  );
-}
-
-export function TempWidget() {
-  return (
-    <Suspense fallback={<TempWidgetSkeleton />}>
-      {/* @ts-expect-error Server Component */}
-      <TempWidgetAsync />
-    </Suspense>
   );
 }

--- a/components/UpdatedAt.tsx
+++ b/components/UpdatedAt.tsx
@@ -1,10 +1,7 @@
 import { formatTime } from "@/lib/formatTime";
-import { getOpenWeather } from "@/lib/getOpenWeather";
-import { Suspense } from "react";
+import { OpenWeather } from "@/lib/getOpenWeather";
 
-export async function UpdatedAtAsync() {
-  const weather = await getOpenWeather();
-
+export function UpdatedAt({ weather }: { weather: OpenWeather }) {
   const time = formatTime({
     date: weather.current.dt,
     showSeconds: true,
@@ -17,14 +14,5 @@ export async function UpdatedAtAsync() {
 export function UpdatedAtSkeleton() {
   return (
     <div className="my-1 h-4 w-full animate-pulse rounded-lg bg-gray-700 bg-opacity-50"></div>
-  );
-}
-
-export function UpdatedAt() {
-  return (
-    <Suspense fallback={<UpdatedAtSkeleton />}>
-      {/* @ts-expect-error Server Component */}
-      <UpdatedAtAsync />
-    </Suspense>
   );
 }

--- a/components/WindWidget.tsx
+++ b/components/WindWidget.tsx
@@ -1,15 +1,8 @@
-import { getOpenWeather } from "@/lib/getOpenWeather";
-import {
-  IconArrowDownCircle,
-  IconTemperature,
-  IconWind,
-} from "@tabler/icons-react";
-import { Suspense } from "react";
+import { OpenWeather } from "@/lib/getOpenWeather";
+import { IconArrowDownCircle, IconWind } from "@tabler/icons-react";
 import { OneByOne } from "./base-widgets";
 
-export async function WindWidgetAsync() {
-  const weather = await getOpenWeather();
-
+export function WindWidget({ weather }: { weather: OpenWeather }) {
   return (
     <OneByOne className="flex flex-col">
       <div className="flex items-center gap-1 text-sm text-gray-400">
@@ -51,15 +44,6 @@ export function WindWidgetSkeleton() {
         <div className="flex h-20 w-1/2 animate-pulse flex-col items-center rounded-lg bg-gray-700 bg-opacity-90"></div>
       </div>{" "}
     </OneByOne>
-  );
-}
-
-export function WindWidget() {
-  return (
-    <Suspense fallback={<WindWidgetSkeleton />}>
-      {/* @ts-expect-error Server Component */}
-      <WindWidgetAsync />
-    </Suspense>
   );
 }
 

--- a/lib/getOpenWeather.ts
+++ b/lib/getOpenWeather.ts
@@ -156,7 +156,7 @@ export async function getOpenWeather(): Promise<OpenWeather> {
   const res: unknown = await fetch(
     `https://api.openweathermap.org/data/3.0/onecall?${query.toString()}`,
     {
-      next: { revalidate: 0 },
+      next: { revalidate: 120 },
     }
   ).then((res) => res.json());
 

--- a/lib/getOpenWeather.ts
+++ b/lib/getOpenWeather.ts
@@ -154,8 +154,7 @@ export async function getOpenWeather(): Promise<OpenWeather> {
   await new Promise((resolve) => setTimeout(resolve, 1000));
 
   const res: unknown = await fetch(
-    `https://api.openweathermap.org/data/3.0/onecall?${query.toString()}`,
-    { next: { revalidate: 60 * 2 } }
+    `https://api.openweathermap.org/data/3.0/onecall?${query.toString()}`
   ).then((res) => res.json());
 
   return openWeatherSchema.parse(res);

--- a/lib/getOpenWeather.ts
+++ b/lib/getOpenWeather.ts
@@ -154,7 +154,10 @@ export async function getOpenWeather(): Promise<OpenWeather> {
   await new Promise((resolve) => setTimeout(resolve, 1000));
 
   const res: unknown = await fetch(
-    `https://api.openweathermap.org/data/3.0/onecall?${query.toString()}`
+    `https://api.openweathermap.org/data/3.0/onecall?${query.toString()}`,
+    {
+      next: { revalidate: 0 },
+    }
   ).then((res) => res.json());
 
   return openWeatherSchema.parse(res);

--- a/lib/getTerpsWeather.ts
+++ b/lib/getTerpsWeather.ts
@@ -48,7 +48,6 @@ export async function getTerpsWeather(
           "windDir",
         ],
       }),
-      next: { revalidate: 0 },
     }
   ).then((res) => res.json());
 


### PR DESCRIPTION
I thought that updating to this new data fetching pattern would help with the data revalidation issue I'm having, but no luck. Before, each individual widget would call the `getOpenWeather()` component itself, and I was just relying on Next.js to be smart enough to combine all of these fetch requests and send out one instead of a bunch. Now, I'm just calling that function once and then passing the result to each widget. Because of this, I'm now relying on the file `loading.tsx` to do loading state and all of that instead of the React `Suspense` component with the fallback.

Either way, the site deploys as entirely static on Vercel and all of the data is prefetched and prerendered. I even tried doing both the `next.revalidate` option in the fetch API and the revalidate route segment config, but neither did this properly.

Hopefully this is all fixed soon, I know that there have been others having similar issues with revalidate. All of that aside, this is pretty cool tech and there's some rough edges to be expected in beta software :)